### PR TITLE
Fix module setup and clean e2e test

### DIFF
--- a/src/gateway/gateway.module.ts
+++ b/src/gateway/gateway.module.ts
@@ -5,8 +5,7 @@ import { GatewayController } from './gateway.controller';
 import { GatewayApp } from './gateway';
 
 @Module({
-  imports: [GatewayApp],
   providers: [GatewayApp, GatewayService],
-  controllers: [GatewayController]
+  controllers: [GatewayController],
 })
 export class GatewayModule {}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,11 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {
-  let app: INestApplication<App>;
+  let app: INestApplication;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
## Summary
- remove invalid `imports` from GatewayModule
- fix incorrect type import in e2e test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684faef123148320aa5fdbb431561618